### PR TITLE
Changes endpoint to be a configurable value

### DIFF
--- a/example.js
+++ b/example.js
@@ -2,7 +2,7 @@
 
 const {inspect} = require('util')
 
-const vbb = require('.')
+const vbb = require('.')()
 
 vbb.journeys('900000003201', '900000024101', {results: 1})
 .then((data) => {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const ndjson = require('ndjson').parse
 const {PassThrough} = require('stream')
 
-const request = require('./lib/request')
+const request = require('./lib/request')()
 
 const isProd = process.env.NODE_ENV === 'production'
 const isObj = o => 'object' === typeof o && !Array.isArray(o)

--- a/index.js
+++ b/index.js
@@ -3,10 +3,27 @@
 const ndjson = require('ndjson').parse
 const {PassThrough} = require('stream')
 
-const request = require('./lib/request')()
+let request;
 
 const isProd = process.env.NODE_ENV === 'production'
 const isObj = o => 'object' === typeof o && !Array.isArray(o)
+
+const configure = (config) => {
+	request = require('./lib/request')(config);
+	return {
+		stations,
+		nearby,
+		allStations,
+		station,
+		departures,
+		lines,
+		line,
+		journeys,
+		locations,
+		map,
+		radar
+	}
+}
 
 const stations = (query = {}) => {
 	if (!isProd && !isObj(query)) throw new Error('query must be an object.')
@@ -183,12 +200,4 @@ const radar = (north, west, south, east, query = {}) => {
 	return request('/radar', query)
 }
 
-module.exports = {
-	stations, nearby, allStations,
-	station, departures,
-	lines, line,
-	journeys,
-	locations,
-	map,
-	radar
-}
+module.exports = configure

--- a/lib/request.js
+++ b/lib/request.js
@@ -4,16 +4,18 @@ const qs = require('querystring')
 const Promise = require('pinkie-promise')
 const {fetch} = require('fetch-ponyfill')({Promise})
 
-const endpoint = 'https://2.vbb.transport.rest'
-const userAgent = 'https://github.com/derhuerst/vbb-client'
+const defaults = {
+	endpoint: 'https://2.vbb.transport.rest',
+	userAgent: 'https://github.com/derhuerst/vbb-client',
+}
 
-const request = (route, query, outStream) => {
+const request = (config, route, query, outStream) => {
 	if ('string' !== typeof route) throw new Error('route must be a string')
 	if ('object' !== typeof query) throw new Error('query must be an object')
 
 	query = Object.assign({}, query)
 	const headers = {}
-	if (!process.browser) headers['User-Agent'] = userAgent
+	if (!process.browser) headers['User-Agent'] = config.userAgent
 	if ('identifier' in query) {
 		headers['X-Identifier'] = query.identifier
 		delete query.identifier
@@ -27,34 +29,41 @@ const request = (route, query, outStream) => {
 	const err = new Error()
 	err.isHafasError = true
 
-	const req = fetch(endpoint + route + '?' + qs.stringify(query), {
-		mode: 'cors',
-		redirect: 'follow',
-		headers
-	})
-	.then((res) => {
-		if (!res.ok) {
-			err.message = res.statusText
-			err.statusCode = res.status
-			throw err
-		}
-		return res
-	})
+	const req = fetch(config.endpoint + route + '?' + qs.stringify(query), {
+			mode: 'cors',
+			redirect: 'follow',
+			headers
+		})
+		.then((res) => {
+			if (!res.ok) {
+				err.message = res.statusText
+				err.statusCode = res.status
+				throw err
+			}
+			return res
+		})
 
 	if (outStream) {
 		const onError = err => outStream.destroy(err)
 		req
-		.then((res) => {
-			res.body.once('error', onError)
-			res.body.pipe(outStream)
-		})
-		.catch(onError)
+			.then((res) => {
+				res.body.once('error', onError)
+				res.body.pipe(outStream)
+			})
+			.catch(onError)
 
 		return outStream
 	} else {
 		return req
-		.then(res => res.json())
+			.then(res => res.json())
 	}
 }
 
-module.exports = request
+const constructor = (config) => {
+	if (typeof config === 'undefined') {
+		config = defaults;
+	}
+	return request.bind(null, config);
+}
+
+module.exports = constructor

--- a/lib/request.js
+++ b/lib/request.js
@@ -59,10 +59,9 @@ const request = (config, route, query, outStream) => {
 	}
 }
 
-const constructor = (config) => {
-	if (typeof config === 'undefined') {
-		config = defaults;
-	}
+const constructor = (customConfig) => {
+	const config = Object.assign({}, defaults, customConfig)
+
 	return request.bind(null, config);
 }
 

--- a/readme.md
+++ b/readme.md
@@ -20,11 +20,19 @@ npm install vbb-client
 ## Usage
 
 ```js
-const vbb = require('vbb-client')
+const vbb = require('vbb-client')()
 
 vbb.journeys('900000003201', '900000024101', {results: 1})
 .then(console.log)
 .catch(console.error)
+```
+
+### With Custom Endpoint
+
+```js
+const vbb = require('vbb-client')({
+    endpoint: "http://my.local.api",
+})
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const isPromise = require('is-promise')
 const isStream = require('is-stream')
 const {DateTime} = require('luxon')
 
-const client = require('.')
+const client = require('.')()
 
 const isObj = o => o !== null && 'object' === typeof o && !Array.isArray(o)
 


### PR DESCRIPTION
This change allos for users of the client to define a custom endpoint and user agent.
Without this change the client is unusable as long as the default URL is down.

Unfortunately this breaks the API of the client, so the next release would need to be a major version.
I wasn't able to figure out a nice way of allowing the current behaviour and the new behaviour.


This resolves #9